### PR TITLE
Calling spy() now fills args and kwargs with empty tuple or dictionary

### DIFF
--- a/sinon/lib/spy.py
+++ b/sinon/lib/spy.py
@@ -57,7 +57,7 @@ class SinonSpy(SinonBase): #pylint: disable=too-many-public-methods
         if len(self.args) > 0:
             new_args_list = []
             for item in self.args:
-                if self.obj == item[0].__class__:
+                if len(item) > 0 and self.obj == item[0].__class__:
                     new_args_list.append(item[1:])
                 else:
                     new_args_list.append(item[:])

--- a/sinon/lib/util/Wrapper.py
+++ b/sinon/lib/util/Wrapper.py
@@ -60,10 +60,8 @@ def __add_spy(func):
         """
         wrapped.callCount += 1
         CALLQUEUE.append(wrapped)
-        if args:
-            wrapped.args_list.append(args)
-        if kwargs:
-            wrapped.kwargs_list.append(kwargs)
+        wrapped.args_list.append(args)
+        wrapped.kwargs_list.append(kwargs)
         try:
             ret = func(*args, **kwargs)
             wrapped.ret_list.append(ret)

--- a/sinon/test/TestSinonSpy.py
+++ b/sinon/test/TestSinonSpy.py
@@ -34,6 +34,10 @@ def D_func(err=False):
         raise err
     else:
         return "test_local_D_func"
+
+def E_func(*args, **kwargs):
+    return str(args) + ' ' + str(kwargs)
+
 """
 ======================================================
                  FOR TEST ONLY END
@@ -852,3 +856,15 @@ class TestSinonSpy(unittest.TestCase):
         self.assertTrue(spy.neverCalledWithMatch("a", "e"))
         self.assertTrue(spy.neverCalledWithMatch("d", "e", "c")) #it's a combination
 
+    @sinontest
+    def test270_args_and_kwargs(self):
+        spy = SinonSpy(E_func)
+        sinon.g.E_func()
+        self.assertListEqual(spy.args, [()])
+        self.assertListEqual(spy.kwargs, [{}])
+        sinon.g.E_func(1, a=1)
+        self.assertListEqual(spy.args, [(), (1,)])
+        self.assertListEqual(spy.kwargs, [{}, {'a':1}])
+        sinon.g.E_func(1, 2, a=1, b=2)
+        self.assertListEqual(spy.args, [(), (1,), (1,2)])
+        self.assertListEqual(spy.kwargs, [{}, {'a':1}, {'a':1,'b':2}])


### PR DESCRIPTION
The next fixes will build on top of this one