### PR TITLE
Can now call non-pure stub directly

### DIFF
--- a/sinon/lib/sandbox.py
+++ b/sinon/lib/sandbox.py
@@ -36,7 +36,7 @@ def sinontest(test_func):
         for item in SinonBase._queue: #pylint: disable=protected-access
             original_queue.append(item)
 
-        SpyCall.next_spy_call_id = 0
+        SpyCall._next_spy_call_id = 0
         ret = test_func(*args, **kwargs)
 
         # handle indirect use (called by sinon.py)

--- a/sinon/lib/spy.py
+++ b/sinon/lib/spy.py
@@ -69,52 +69,35 @@ class SinonSpy(SinonBase): #pylint: disable=too-many-public-methods
         For solving special case of mock
         Args: List (new argument list)
         """
-        self.__get_wrapper().__set__("args_list", new_args_list)
-
-    def __get_wrapper(self):
-        """
-        Return:
-            Wrapper object
-        Raise:
-            Exception if wrapper object cannot be found
-        """
-        #TODO: consider to remove "PURE" condition
-        if self.args_type == "MODULE_FUNCTION":
-            return getattr(self.obj, self.prop)
-        elif self.args_type == "FUNCTION":
-            return getattr(self.g, self.obj.__name__)
-        elif self.args_type == "PURE":
-            return getattr(self.pure, "func")
-        else:
-            ErrorHandler.wrapper_object_not_found_error()
+        super(SinonSpy, self)._get_wrapper().__set__("args_list", new_args_list)
 
     @property
     def args(self):
         """
         Return: List (arguments which are called)
         """
-        return self.__get_wrapper().args_list
+        return super(SinonSpy, self)._get_wrapper().args_list
 
     @property
     def kwargs(self):
         """
         Return: List (dictionary arguments which are called)
         """
-        return self.__get_wrapper().kwargs_list
+        return super(SinonSpy, self)._get_wrapper().kwargs_list
 
     @property
     def exceptions(self):
         """
         Return: List (exceptions which are happened)
         """
-        return self.__get_wrapper().error_list
+        return super(SinonSpy, self)._get_wrapper().error_list
 
     @property
     def returnValues(self):
         """
         Return: List (returns which are happened)
         """
-        return self.__get_wrapper().ret_list
+        return super(SinonSpy, self)._get_wrapper().ret_list
 
     def withArgs(self, *args, **kwargs):
         """
@@ -132,7 +115,7 @@ class SinonSpy(SinonBase): #pylint: disable=too-many-public-methods
         if self.args_type in ["MODULE", "PURE"]:
             return self.pure_count
         else:
-            return self.__get_wrapper().callCount
+            return super(SinonSpy, self)._get_wrapper().callCount
 
     @property
     def called(self): #pylint: disable=missing-docstring
@@ -176,7 +159,7 @@ class SinonSpy(SinonBase): #pylint: disable=too-many-public-methods
         """
         Return: SpyCall object for this spy's most recent call
         """
-        last_index = len(self.__get_wrapper().call_list) - 1
+        last_index = len(super(SinonSpy, self)._get_wrapper().call_list) - 1
         return self.getCall(last_index)
 
     def calledBefore(self, spy): #pylint: disable=invalid-name
@@ -410,7 +393,7 @@ class SinonSpy(SinonBase): #pylint: disable=too-many-public-methods
         Return:
             SpyCall object (or None if the index is not valid)
         """
-        call_list = self.__get_wrapper().call_list
+        call_list = super(SinonSpy, self)._get_wrapper().call_list
         if n >= 0 and n < len(call_list):
             call = call_list[n]
             call.proxy = weakref.proxy(self)

--- a/sinon/lib/util/SpyCall.py
+++ b/sinon/lib/util/SpyCall.py
@@ -10,7 +10,7 @@ class SpyCall(object):
     Holds data and test functions related to a single function call
     """
 
-    next_spy_call_id = 0
+    _next_spy_call_id = 0
 
     def __init__(self):
         """
@@ -18,8 +18,8 @@ class SpyCall(object):
         """
         self.args = []
         self.kwargs = []
-        self.callId = SpyCall.next_spy_call_id
-        SpyCall.next_spy_call_id += 1
+        self.callId = SpyCall._next_spy_call_id
+        SpyCall._next_spy_call_id += 1
         self.exception = None
         self.proxy = None
         self.returnValue = None

--- a/sinon/test/TestSinonStub.py
+++ b/sinon/test/TestSinonStub.py
@@ -228,3 +228,31 @@ class TestSinonBase(unittest.TestCase):
         stub = SinonStub()
         stub.withArgs(42).returns(1)
         self.assertEqual(stub(42), 1)
+
+    @sinontest
+    def test360_pure_returns(self):
+        stub = SinonStub()
+        stub.returns(5)
+        self.assertEqual(stub(), 5)
+
+    @sinontest
+    def test361_module_returns(self):
+        stub = SinonStub(os, 'system')
+        stub.returns(5)
+        self.assertEqual(os.system(), 5)
+        self.assertEqual(stub(), 5)
+
+    @sinontest
+    def test362_function_returns(self):
+        stub = SinonStub(C_func)
+        stub.returns(5)
+        self.assertEqual(stub.g.C_func(), 5)
+        self.assertEqual(stub(), 5)
+
+    @sinontest
+    def test363_method_returns(self):
+        o = A_object()
+        stub = SinonStub(o, 'A_func')
+        stub.returns(5)
+        self.assertEqual(o.A_func(), 5)
+        self.assertEqual(stub(), 5)


### PR DESCRIPTION
I moved __get_wrapper from `SinonSpy` up to `SinonBase`, and fixed `SinonBase.__call__`

I also made a small fix to `SpyCall`... let me know if you want that in a separate fix

Fixes note35/sinon#15